### PR TITLE
Test database

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -14,3 +14,13 @@ web_profiler:
 
 swiftmailer:
     disable_delivery: true
+
+doctrine_mongodb:
+    connections:
+        default:
+            server: %mongodb_server%
+            options: {}
+    default_database: %mongodb_test_database%
+    document_managers:
+        default:
+            auto_mapping: true

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -2,6 +2,7 @@
 parameters:
     mongodb_server:   mongodb://localhost:27017
     mongodb_database: restaurant
+    mongodb_test_database: restaurant_test
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1

--- a/src/Restaurant/AuthBundle/Tests/Document/UserTest.php
+++ b/src/Restaurant/AuthBundle/Tests/Document/UserTest.php
@@ -2,7 +2,7 @@
 
 namespace Restaurant\AuthBundle\Tests\Document;
 
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Restaurant\TablesBundle\Tests\KernelTestCase;
 use Restaurant\AuthBundle\Document\User;
 use Doctrine\ODM\MongoDB\DocumentManager;
 

--- a/src/Restaurant/TablesBundle/Tests/KernelTestCase.php
+++ b/src/Restaurant/TablesBundle/Tests/KernelTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Restaurant\TablesBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase as BaseKernelTestCase;
+
+
+/**
+ * @inheritDoc
+ */
+abstract class KernelTestCase extends BaseKernelTestCase {
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass()
+    {
+        static::bootKernel();
+        $container = static::$kernel->getContainer();
+        $db_connection = $container->get('doctrine_mongodb.odm.default_connection');
+        $test_db_name = $container->getParameter('mongodb_test_database');
+        $db_connection->dropDatabase($test_db_name);
+    }
+
+}

--- a/src/Restaurant/TablesBundle/Tests/WebTestCase.php
+++ b/src/Restaurant/TablesBundle/Tests/WebTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Restaurant\TablesBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as BaseWebTestCase;
+
+
+/*
+ * @inheritDoc
+ */
+abstract class WebTestCase extends BaseWebTestCase {
+
+    /**
+     * @inheritDoc
+     */
+    public static function tearDownAfterClass()
+    {
+        static::bootKernel();
+        $container = static::$kernel->getContainer();
+        $db_connection = $container->get('doctrine_mongodb.odm.default_connection');
+        $test_db_name = $container->getParameter('mongodb_test_database');
+        $db_connection->dropDatabase($test_db_name);
+    }
+
+}


### PR DESCRIPTION
Refs #26 

- Se usa una base de datos alternativa para ejecutar las pruebas.
- Se proveen clases base para pruebas que eliminan la base de datos, para así asegurar una base de datos vacía al inicio de las pruebas