### PR TITLE
54 incremento cobertura

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -875,12 +875,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/mongodb-odm.git",
-                "reference": "0f5e7d72ea1859f57b254e93bcb50433e64e755e"
+                "reference": "91239639b5b5c91a75ac2a07dbbfe4be0fd177d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/0f5e7d72ea1859f57b254e93bcb50433e64e755e",
-                "reference": "0f5e7d72ea1859f57b254e93bcb50433e64e755e",
+                "url": "https://api.github.com/repos/doctrine/mongodb-odm/zipball/91239639b5b5c91a75ac2a07dbbfe4be0fd177d9",
+                "reference": "91239639b5b5c91a75ac2a07dbbfe4be0fd177d9",
                 "shasum": ""
             },
             "require": {
@@ -945,7 +945,7 @@
                 "odm",
                 "persistence"
             ],
-            "time": "2015-05-12 23:07:56"
+            "time": "2015-05-14 16:54:33"
         },
         {
             "name": "doctrine/mongodb-odm-bundle",
@@ -953,12 +953,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineMongoDBBundle.git",
-                "reference": "428c21fd3bea9e27281784bcae2db9b7516b318e"
+                "reference": "9e98fd9def517c68c8b8db43333545faef9a94b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineMongoDBBundle/zipball/428c21fd3bea9e27281784bcae2db9b7516b318e",
-                "reference": "428c21fd3bea9e27281784bcae2db9b7516b318e",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMongoDBBundle/zipball/9e98fd9def517c68c8b8db43333545faef9a94b6",
+                "reference": "9e98fd9def517c68c8b8db43333545faef9a94b6",
                 "shasum": ""
             },
             "require": {
@@ -1015,7 +1015,7 @@
                 "persistence",
                 "symfony"
             ],
-            "time": "2015-04-15 14:15:44"
+            "time": "2015-05-14 17:52:49"
         },
         {
             "name": "friendsofsymfony/rest-bundle",

--- a/src/Restaurant/TablesBundle/Document/OrderItem.php
+++ b/src/Restaurant/TablesBundle/Document/OrderItem.php
@@ -7,7 +7,7 @@ namespace Restaurant\TablesBundle\Document;
 class OrderItem
 {
     protected $id;
-    protected $menu_item;
+    protected $menuItem;
     protected $observations;
 
 
@@ -51,7 +51,7 @@ class OrderItem
      */
     public function setMenuItem(\Restaurant\TablesBundle\Document\MenuItem $menuItem)
     {
-        $this->menu_item = $menuItem;
+        $this->menuItem = $menuItem;
         return $this;
     }
 
@@ -62,6 +62,6 @@ class OrderItem
      */
     public function getMenuItem()
     {
-        return $this->menu_item;
+        return $this->menuItem;
     }
 }

--- a/src/Restaurant/TablesBundle/Resources/config/doctrine/OrderItem.mongodb.yml
+++ b/src/Restaurant/TablesBundle/Resources/config/doctrine/OrderItem.mongodb.yml
@@ -6,6 +6,6 @@ Restaurant\TablesBundle\Document\OrderItem:
         observations:
             type: string
     referenceOne:
-        menu_item:
+        menuItem:
             targetDocument: MenuItem
             cascade: all

--- a/src/Restaurant/TablesBundle/Tests/Document/MenuItemTest.php
+++ b/src/Restaurant/TablesBundle/Tests/Document/MenuItemTest.php
@@ -46,21 +46,39 @@ class MenuItemTest extends KernelTestCase {
         $this->assertNotNull($this->menuItem->getId());
     }
 
-    public function testUpdate()
+    public function testUpdatePrice()
     {
+        $oldPrice = $this->menuItem->getPrice();
+        $newPrice = 3.5;
         self::$dm->persist($this->menuItem);
         self::$dm->flush();
 
-        $menuItems = self::$dm->createQueryBuilder('\Restaurant\TablesBundle\Document\MenuItem')
-            ->findAndUpdate()
-            ->field("id")->equals($this->menuItem->getId())
-            ->field("price")->set(3.00)
-            ->getQuery()->execute();
+        $this->menuItem->setPrice($newPrice);
+        $docMenuItem = self::$dm->find("RestaurantTablesBundle:MenuItem", $this->menuItem->getId());
+        $this->assertNotEquals($oldPrice, $docMenuItem->getPrice());
+    }
 
-        foreach ($menuItems as $m) {
-            $this->assertNotEquals($this->menuItem->getPrice(), $m->getPrice());
-        }
+    public function testUpdateName()
+    {
+        $oldName = $this->menuItem->getName();
+        $newName = "Falafel verde";
+        self::$dm->persist($this->menuItem);
+        self::$dm->flush();
 
+        $this->menuItem->setName($newName);
+        $docMenuItem = self::$dm->find("RestaurantTablesBundle:MenuItem", $this->menuItem->getId());
+        $this->assertNotEquals($oldName, $docMenuItem->getName());
+    }
+
+    public function testUpdateAvailable()
+    {
+        $oldAvailable = $this->menuItem->getAvailable();
+        self::$dm->persist($this->menuItem);
+        self::$dm->flush();
+
+        $this->menuItem->setAvailable(false);
+        $docMenuItem = self::$dm->find("RestaurantTablesBundle:MenuItem", $this->menuItem->getId());
+        $this->assertNotEquals($oldAvailable, $docMenuItem->getAvailable());
     }
 
     public function testRemove()

--- a/src/Restaurant/TablesBundle/Tests/Document/OrderItemTest.php
+++ b/src/Restaurant/TablesBundle/Tests/Document/OrderItemTest.php
@@ -59,7 +59,23 @@ class OrderItemTest extends KernelTestCase {
         $this->assertNotNull($this->orderItem->getId());
     }
 
-    public function testUpdate()
+    public function testUpdateObservations()
+    {
+        $oldObservations = $this->orderItem->getObservations();
+        $newObservations = "Sin sal y picante";
+        self::$dm->persist($this->menuItem);
+        self::$dm->flush();
+
+        $this->orderItem->setMenuItem($this->menuItem);
+        self::$dm->persist($this->orderItem);
+        self::$dm->flush();
+
+        $this->orderItem->setObservations($newObservations);
+        $docOrderItem = self::$dm->find("RestaurantTablesBundle:OrderItem", $this->orderItem->getId());
+        $this->assertNotEquals($oldObservations, $docOrderItem->getObservations());
+    }
+
+    public function testMenuItem()
     {
         self::$dm->persist($this->menuItem);
         self::$dm->flush();
@@ -68,16 +84,8 @@ class OrderItemTest extends KernelTestCase {
         self::$dm->persist($this->orderItem);
         self::$dm->flush();
 
-        $orderItems = self::$dm->createQueryBuilder('\Restaurant\TablesBundle\Document\OrderItem')
-            ->findAndUpdate()
-            ->field("id")->equals($this->orderItem->getId())
-            ->field("observations")->set("Sin sal y aceite")
-            ->getQuery()->execute();
-
-        foreach ($orderItems as $oi) {
-            $this->assertNotEquals($this->orderItem->getObservations(), $oi->getObservations());
-        }
-
+        $menuItemId = $this->menuItem->getId();
+        $this->assertEquals($menuItemId, $this->orderItem->getMenuItem()->getId());
     }
 
     public function testRemove()

--- a/src/Restaurant/TablesBundle/Tests/Document/ReservationTest.php
+++ b/src/Restaurant/TablesBundle/Tests/Document/ReservationTest.php
@@ -60,7 +60,7 @@ class ReservationTest extends KernelTestCase {
         $this->assertNotNull($this->reservation->getId());
     }
 
-    public function testUpdate()
+    public function testUpdateEstimatedArrivalTime()
     {
         self::$dm->persist($this->client);
         self::$dm->flush();
@@ -69,15 +69,25 @@ class ReservationTest extends KernelTestCase {
         self::$dm->persist($this->reservation);
         self::$dm->flush();
 
-        $docReservation = self::$dm->createQueryBuilder('\Restaurant\TablesBundle\Document\Reservation')
-            ->findAndUpdate()
-            ->field("id")->equals($this->reservation->getId())
-            ->field("estimatedArrivalTime")->set(new \DateTime("2015-05-03 01:00:00"))
-            ->getQuery()->execute();
-        foreach ($docReservation as $r) {
-            $this->assertNotEquals($this->reservation->getEstimatedArrivalTime(), $r->getEstimatedTime());
-        }
+        $oldETA = $this->reservation->getEstimatedArrivalTime();
+        $newETA = "2015-05-03 01:00:00";
+        $this->reservation->setEstimatedArrivalTime($newETA);
+        $docReservation = self::$dm->find("RestaurantTablesBundle:Reservation", $this->reservation->getId());
+        $this->assertNotEquals($oldETA, $docReservation->getEstimatedArrivalTime());
+    }
 
+    public function testClient()
+    {
+        self::$dm->persist($this->client);
+        self::$dm->flush();
+
+        $this->reservation->setClient($this->client);
+        self::$dm->persist($this->reservation);
+        self::$dm->flush();
+
+        $clientId = $this->client->getId();
+        $docReservation = self::$dm->find("RestaurantTablesBundle:Reservation", $this->reservation->getId());
+        $this->assertEquals($clientId, $docReservation->getClient()->getId());
     }
 
     public function testRemove()

--- a/src/Restaurant/TablesBundle/Tests/Document/StoreTest.php
+++ b/src/Restaurant/TablesBundle/Tests/Document/StoreTest.php
@@ -62,8 +62,10 @@ class StoreTest extends KernelTestCase {
         $this->assertNotNull($this->store->getId());
     }
 
-    public function testUpdate()
+    public function testUpdateAddress()
     {
+        $oldAddress = $this->store->getAddress();
+        $newAddress = "Av. Larco 500";
         self::$dm->persist($this->employee);
         self::$dm->flush();
 
@@ -71,15 +73,23 @@ class StoreTest extends KernelTestCase {
         self::$dm->persist($this->store);
         self::$dm->flush();
 
-        $stores = self::$dm->createQueryBuilder('\Restaurant\TablesBundle\Document\Store')
-            ->findAndUpdate()
-            ->field("id")->equals($this->store->getId())
-            ->field("address")->set("Av. Larco 500")
-            ->getQuery()->execute();
-        foreach($stores as $s)
-        {
-            $this->assertNotEquals($this->store->getAddress(), $s->getAddress());
-        }
+        $this->store->setAddress($newAddress);
+        $docStore = self::$dm->find("RestaurantTablesBundle:Store", $this->store->getId());
+        $this->assertNotEquals($oldAddress, $docStore->getAddress());
+    }
+
+    public function testManager()
+    {
+        self::$dm->persist($this->employee);
+        self::$dm->flush();
+        $managerId = $this->employee->getId();
+
+        $this->store->setManager($this->employee);
+        self::$dm->persist($this->store);
+        self::$dm->flush();
+
+        $docStore = self::$dm->find("RestaurantTablesBundle:Store", $this->store->getId());
+        $this->assertEquals($managerId, $docStore->getManager()->getId());
     }
 
     public function testRemove()


### PR DESCRIPTION
Se ha rediseñado las pruebas para que efectivamente empleen el assert. Además se ha incrementado la cobertura con nuevas pruebas que emplean los métodos de get y set para las entidades.

No considerar el cambio de composer.lock Fixes #54 